### PR TITLE
Add PHP 8.1 compatibility to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "getkirby/composer-installer": "^1.1",
         "indieweb/mention-client": "^1.2",
-        "php": ">=7.3.0 <8.1.0"
+        "php": ">=7.3.0 <=8.1"
     },
     "suggests": {
         "mauricerenck/indieconnector": "1.2"


### PR DESCRIPTION
I have tested the plugin with PHP 8.1 and it still works but throws an error message in composer because of the <8.1 definition