### PR TITLE
fix thank you message translation

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@ use mauricerenck\Komments\KommentModeration;
 use mauricerenck\Komments\KommentReceiver;
 use Kirby;
 use Kirby\Http\Response;
+use Kirby\Toolkit\I18n;
 
 @include_once __DIR__ . '/vendor/autoload.php';
 
@@ -70,7 +71,7 @@ Kirby::plugin('mauricerenck/komments', [
                     $response = [
                         'status' => 'success',
                         'pending' => true,
-                        'message' => t('mauricerenck.komments.thankyou'),
+                        'message' => I18n::template('mauricerenck.komments.thankyou', null, [], kirby()->languageCode()),
                         'data' => $webmention
                     ];
 

--- a/index.php
+++ b/index.php
@@ -71,7 +71,7 @@ Kirby::plugin('mauricerenck/komments', [
                     $response = [
                         'status' => 'success',
                         'pending' => true,
-                        'message' => I18n::template('mauricerenck.komments.thankyou', null, [], kirby()->languageCode()),
+                        'message' => I18n::translate('mauricerenck.komments.thankyou', null , kirby()->languageCode()),
                         'data' => $webmention
                     ];
 


### PR DESCRIPTION
currently the `mauricerenck.komments.thankyou` message is always shown in the default language, no matter what the current language is. 
maybe related to `t()` helper not working in this context. 

fix by using `I18n::template()` instead.

![Bildschirmfoto 2023-09-18 um 08 46 57](https://github.com/mauricerenck/komments/assets/8297800/d0766d25-f226-4f4d-8be2-10ff86a5fedc)
