### PR TITLE
Fix: Gravatar link is saved instead of the email address

### DIFF
--- a/lib/KommentReceiver.php
+++ b/lib/KommentReceiver.php
@@ -108,8 +108,7 @@ class KommentReceiver
         }
 
         if (V::email($email)) {
-            $mailHash = md5($email);
-            return 'https://www.gravatar.com/avatar/' . $mailHash;
+            return $email;
         }
 
         return null;


### PR DESCRIPTION
I have found a bug where getEmail returns the avatar link, which is then also saved in the comment.