### PR TITLE
fix: check if the x-return-type header is in request headers

### DIFF
--- a/plugin/routes.php
+++ b/plugin/routes.php
@@ -13,7 +13,7 @@ return [
         'action' => function () {
             $headers = kirby()->request()->headers();
             $formData = kirby()->request()->data();
-            $shouldReturnJson = ($headers['X-Return-Type'] === 'json');
+            $shouldReturnJson = (array_key_exists('X-Return-Type', $headers) && $headers['X-Return-Type'] === 'json');
 
             $page = page($formData['pageUuid']);
 


### PR DESCRIPTION
Here I found a way to make the `komment/send' route more robust. In cases where the X-Return-Type header is not set, the code breaks. So it is safer to check if the header is in the headers array before accessing it.

The header is only present if the form is submitted with your `komment.js' form submission request.