### PR TITLE
feat: allow closures in autoPublish config option

### DIFF
--- a/lib/KommentReceiver.php
+++ b/lib/KommentReceiver.php
@@ -9,9 +9,10 @@ use Kirby\Http\Remote;
 class KommentReceiver
 {
 
-    public function __construct(private ?array $autoPublish = null, private ?bool $autoPublishVerified = null, private ?bool $akismet = null, private ?string $akismetApiKey = null, private ?bool $debug = null)
+    public function __construct(private null|array|\Closure $autoPublish = null, private ?bool $autoPublishVerified = null, private ?bool $akismet = null, private ?string $akismetApiKey = null, private ?bool $debug = null)
     {
-        $this->autoPublish = $autoPublish ?? option('mauricerenck.komments.moderation.autoPublish', []);
+        $autoPublishOption = option('mauricerenck.komments.moderation.autoPublish', []);
+        $this->autoPublish = $autoPublish ?? is_callable($autoPublishOption) ? $autoPublishOption() : $autoPublishOption;
         $this->autoPublishVerified = $autoPublishVerified ?? option('mauricerenck.komments.moderation.publish-verified', false);
         $this->akismet = $akismet ?? option('mauricerenck.komments.spam.akismet', false);
         $this->akismetApiKey = $akismetApiKey ?? option('mauricerenck.komments.spam.akismet_api_key', '');


### PR DESCRIPTION
If you are interested in implementing #70, this would be the minial approach to do it.
Maybe a more general solution would be nice. The `akismet_api_key` would be another case were a closure makes sense, especially if the key is set in an env variable.